### PR TITLE
make logger more simple again

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Simple handling class to connect to a sqlite database and send sql-commands to t
 
 ### log-writer
 
-Its a simple logger to wirte messages with timestamps to a log-file. It use internally the binary-files-class, because its faster.
+Its a simple logger to wirte messages with timestamps to a log-file. 
 
 ## Build
 
@@ -252,7 +252,7 @@ testDB.close();
 
 **Header-file:** `logger/logger.h`
 
-Its a simple class to write log-messages together with a timestamp one after another to a log-file. It use internally the binary-files-class, because its faster.
+Its a simple class to write log-messages together with a timestamp one after another to a log-file. 
 
 ```cpp
 #include <logger/logger.h>

--- a/include/libKitsunePersistence/logger/logger.h
+++ b/include/libKitsunePersistence/logger/logger.h
@@ -12,6 +12,9 @@
 #define LOGGER_H
 
 #include <iostream>
+#include <sstream>
+#include <string>
+#include <fstream>
 #include <ctime>
 #include <atomic>
 
@@ -39,16 +42,12 @@ public:
     std::string m_filePath = "";
 
 private:
-    Common::DataBuffer* m_buffer = nullptr;
-    BinaryFile* m_binaryFile = nullptr;
     std::atomic_flag m_lock = ATOMIC_FLAG_INIT;
-
-    uint64_t m_filePosition = 0;
+    std::ofstream m_outputFile;
     bool m_closed = false;
 
     bool logData(const std::string message);
 
-    void resetBuffer(const uint64_t numberOfBlocks);
     const std::string getDatetime();
 };
 


### PR DESCRIPTION
The logger was too over engineered. It was really fast thanks to the
binary-file-class, but way to complicated for what it should do,
because fast logging is nice, but I also don't want to write log-files
with hundreds of megabytes per second.
So now it also use simple string-appending.