### PR TITLE
make logger better handable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+[Unreleased]
+
+### Changed
+- update logger for eaiser handling
+
+
 ## [0.3.0] - 2019-09-08
 
 ### Added

--- a/include/libKitsunePersistence/logger/logger.h
+++ b/include/libKitsunePersistence/logger/logger.h
@@ -25,6 +25,20 @@ namespace Kitsune
 namespace Persistence
 {
 
+std::pair<bool, std::string> initLogger(const std::string directoryPath,
+                                        const std::string baseFileName,
+                                        const bool debugLog=false,
+                                        const bool logOnConsole=false);
+
+bool LOG_debug(const std::string message);
+bool LOG_info(const std::string message);
+bool LOG_warning(const std::string message);
+bool LOG_error(const std::string message);
+
+bool closeLogFile();
+
+//==================================================================================================
+
 class Logger
 {
 public:
@@ -37,15 +51,14 @@ public:
     std::pair<bool, std::string> initLogger();
     void closeLogFile();
 
-    bool debug(const std::string message);
-    bool info(const std::string message);
-    bool warning(const std::string message);
-    bool error(const std::string message);
+    bool logData(const std::string message);
 
     std::string m_filePath = "";
+    bool m_debugLog = false;
+
+    static Kitsune::Persistence::Logger* m_logger;
 
 private:
-    bool m_debugLog = false;
     bool m_logOnConsole = false;
     std::string m_directoryPath = "";
     std::string m_baseFileName = "";
@@ -54,8 +67,6 @@ private:
     std::ofstream m_outputFile;
 
     bool m_active = false;
-
-    bool logData(const std::string message);
 
     const std::string getDatetime();
 };

--- a/src/logger/logger.cpp
+++ b/src/logger/logger.cpp
@@ -15,6 +15,108 @@ namespace Kitsune
 namespace Persistence
 {
 
+Kitsune::Persistence::Logger* Logger::m_logger = nullptr;
+
+/**
+ * @brief initLogger
+ * @param directoryPath
+ * @param baseFileName
+ * @param debugLog
+ * @param logOnConsole
+ * @return
+ */
+std::pair<bool, std::string>
+initLogger(const std::string directoryPath,
+           const std::string baseFileName,
+           const bool debugLog,
+           const bool logOnConsole)
+{
+    if(Logger::m_logger != nullptr)
+    {
+        std::string errorMessage = "logger is already initialized.";
+        return std::pair<bool, std::string>(false, errorMessage);
+    }
+
+    Logger::m_logger = new Kitsune::Persistence::Logger(directoryPath,
+                                                        baseFileName,
+                                                        debugLog,
+                                                        logOnConsole);
+
+    return Logger::m_logger->initLogger();
+}
+
+/**
+ * @brief write debug-message to logfile
+ */
+bool
+LOG_debug(const std::string message)
+{
+    if(Logger::m_logger == nullptr) {
+        return false;
+    }
+
+    if(Logger::m_logger->m_debugLog == false) {
+        return false;
+    }
+
+    return Logger::m_logger->logData("DEBUG: " + message);
+}
+
+/**
+ * @brief write info-message to logfile
+ */
+bool
+LOG_info(const std::string message)
+{
+    if(Logger::m_logger == nullptr) {
+        return false;
+    }
+
+    return Logger::m_logger->logData("INFO: " + message);
+}
+
+/**
+ * @brief write warnign-message to logfile
+ */
+bool
+LOG_warning(const std::string message)
+{
+    if(Logger::m_logger == nullptr) {
+        return false;
+    }
+
+    return Logger::m_logger->logData("WARNING: " + message);
+}
+
+/**
+ * @brief write error-message to logfile
+ */
+bool
+LOG_error(const std::string message)
+{
+    if(Logger::m_logger == nullptr) {
+        return false;
+    }
+
+    return Logger::m_logger->logData("ERROR: " + message);
+}
+
+bool
+closeLogFile()
+{
+    if(Logger::m_logger == nullptr) {
+        return false;
+    }
+
+    Logger::m_logger->closeLogFile();
+    delete Logger::m_logger;
+    Logger::m_logger = nullptr;
+
+    return true;
+}
+
+//==================================================================================================
+
 /**
  * @brief constructor
  */
@@ -27,8 +129,6 @@ Logger::Logger(const std::string directoryPath,
     m_logOnConsole = logOnConsole;
     m_directoryPath = directoryPath;
     m_baseFileName = baseFileName;
-
-
 }
 
 /**
@@ -104,46 +204,6 @@ Logger::closeLogFile()
     m_outputFile.close();
 
     m_lock.unlock();
-}
-
-/**
- * @brief write debug-message to logfile
- */
-bool
-Logger::debug(const std::string message)
-{
-    if(m_debugLog == false) {
-        return false;
-    }
-
-    return logData("DEBUG: " + message);
-}
-
-/**
- * @brief write info-message to logfile
- */
-bool
-Logger::info(const std::string message)
-{
-    return logData("INFO: " + message);
-}
-
-/**
- * @brief write warnign-message to logfile
- */
-bool
-Logger::warning(const std::string message)
-{
-    return logData("WARNING: " + message);
-}
-
-/**
- * @brief write error-message to logfile
- */
-bool
-Logger::error(const std::string message)
-{
-    return logData("ERROR: " + message);
 }
 
 /**

--- a/tests/libKitsunePersistence/logger/logger_test.cpp
+++ b/tests/libKitsunePersistence/logger/logger_test.cpp
@@ -28,34 +28,32 @@ Logger_Test::Logger_Test()
 void
 Logger_Test::logger_test()
 {
-    Logger testLogger("/tmp", "testlog", true);
-
     // init logger
-    std::pair<bool, std::string> ret = testLogger.initLogger();
+    std::pair<bool, std::string> ret = initLogger("/tmp", "testlog", true);
     UNITTEST(ret.first, true);
 
     // negative-test to try reinit the logger
-    ret = testLogger.initLogger();
+    ret = initLogger("/tmp", "testlog", true);
     UNITTEST(ret.first, false);
 
     // write test-data
-    UNITTEST(testLogger.error("error1"), true);
-    UNITTEST(testLogger.error("error2"), true);
-    UNITTEST(testLogger.error("error3"), true);
+    UNITTEST(LOG_error("error1"), true);
+    UNITTEST(LOG_error("error2"), true);
+    UNITTEST(LOG_error("error3"), true);
 
-    UNITTEST(testLogger.warning("warning1"), true);
-    UNITTEST(testLogger.warning("warning2"), true);
-    UNITTEST(testLogger.warning("warning3"), true);
+    UNITTEST(LOG_warning("warning1"), true);
+    UNITTEST(LOG_warning("warning2"), true);
+    UNITTEST(LOG_warning("warning3"), true);
 
-    UNITTEST(testLogger.debug("debug1"), true);
-    UNITTEST(testLogger.debug("debug2"), true);
-    UNITTEST(testLogger.debug("debug3"), true);
+    UNITTEST(LOG_debug("debug1"), true);
+    UNITTEST(LOG_debug("debug2"), true);
+    UNITTEST(LOG_debug("debug3"), true);
 
-    UNITTEST(testLogger.info("info1"), true);
-    UNITTEST(testLogger.info("info2"), true);
-    UNITTEST(testLogger.info("info3"), true);
+    UNITTEST(LOG_info("info1"), true);
+    UNITTEST(LOG_info("info2"), true);
+    UNITTEST(LOG_info("info3"), true);
 
-    const std::string logContent = readFile(testLogger.m_filePath).second;
+    const std::string logContent = readFile(Logger::m_logger->m_filePath).second;
     std::size_t found;
 
     // error
@@ -89,8 +87,8 @@ Logger_Test::logger_test()
     found = logContent.find("poi");
     UNITTEST(found, std::string::npos);
 
-    testLogger.closeLogFile();
-    deleteFile(testLogger.m_filePath);
+    deleteFile(Logger::m_logger->m_filePath);
+    closeLogFile();
 }
 
 /**


### PR DESCRIPTION
Its really bad to haver every time to manually handle and call a pointer to
the logger. Additionally there is normally only one logger per tool. So I
made the logger static with methods, which can be called directly from
every point of the code without directly accessing a pointer. So, even
the logger is not initialized, there is no manually check in every log-output.
Thats make logging much more easier. Tests of the logger were also updated.

close #19